### PR TITLE
Add Python package configuration and build system support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__/
+build/
+dist/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "van-rally"
+version = "0.1.0"
+description = "Roadsurfer Van-Rally Routes Checker"
+requires-python = ">=3.12"
+dependencies = [
+    "requests",
+]
+
+[tool.setuptools]
+py-modules = ["main", "api_utils", "data_utils", "output_handler", "translations"]
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+]


### PR DESCRIPTION
## Overview

This PR introduces a proper Python package configuration using `pyproject.toml`, enabling the project to be installed as a package and establishing a foundation for better dependency management and distribution.

## Changes Made

### 1. **Added `pyproject.toml`**
- Created a modern Python package configuration following PEP 621 standards
- Defined project metadata:
  - Package name: `van-rally`
  - Version: `0.1.0`
  - Description: Roadsurfer Van-Rally Routes Checker
  - Python version requirement: `>=3.12`
- Specified production dependency: `requests`
- Configured setuptools to recognize all main modules: `main`, `api_utils`, `data_utils`, `output_handler`, `translations`
- Added optional development dependencies:
  - `ruff` for linting and code formatting

### 2. **Enhanced `.gitignore`**
- Added Python build artifacts to `.gitignore`:
  - `build/` - Build directory
  - `dist/` - Distribution directory
  - `*.egg-info/` - Package metadata directory
- Fixed missing newline at end of file
- Ensures clean repository without build artifacts

## Benefits

### For Users
- **Easy Installation**: Users can now install the package using `pip install .` or `pip install -e .` for development
- **Dependency Management**: Automatically installs required dependencies (`requests`)
- **Better Portability**: Package can be distributed and installed on any system with Python 3.12+

### For Developers
- **Development Environment**: Optional dev dependencies (`ruff`) can be installed with `pip install -e .[dev]`
- **Standard Structure**: Follows Python packaging best practices
- **Clean Repository**: Build artifacts are properly ignored

## Installation Methods After This PR

### Standard Installation
```bash
pip install .
```

### Development Installation
```bash
pip install -e .[dev]
```

## Testing
- Verified that `pyproject.toml` syntax is valid
- Confirmed all module names are correctly listed
- Tested that `.gitignore` patterns work as expected

## Breaking Changes
None. The script can still be run directly with `python main.py` as before.

## Future Enhancements
This PR lays the groundwork for:
- Adding more development tools
- Creating entry points for CLI commands