### PR TITLE
feat: Implement GitHub actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
       - name: Install ruff
-        run: pip install ruff
+        run: pip install -e ".[dev]"
       - name: Run ruff
         run: python -m ruff check .
 
@@ -108,11 +108,11 @@ jobs:
         with:
           name: dist
           path: dist/
-      - name: Install package and test tools
+      - name: Install package and dev tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/*.whl
-          python -m pip install pytest pytest-mock
+          python -m pip install -e ".[dev]"
       - name: Run pytest
         run: python -m pytest tests/ -v
 
@@ -138,11 +138,11 @@ jobs:
         with:
           name: dist
           path: dist/
-      - name: Install package and coverage tools
+      - name: Install package and dev tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/*.whl
-          python -m pip install pytest pytest-cov
+          python -m pip install -e ".[dev]"
       - name: Run tests with coverage and enforce threshold
         run: |
           python -m pytest --cov=api_utils --cov=data_utils --cov=main \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, feature/* ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ruff:
+    name: Ruff Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run ruff
+        run: |
+          python -m ruff check .
+
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    needs: ruff
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run pytest
+        run: |
+          python -m pytest tests/ -v
+
+  coverage:
+    name: Coverage (fail if < 80%)
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run tests with coverage and enforce threshold
+        run: |
+          python -m pytest --cov=api_utils --cov=data_utils --cov=main \
+            --cov-report=term-missing --cov-fail-under=80 tests/
+      - name: Upload coverage HTML (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,55 +7,142 @@ on:
     branches: [ main ]
 
 jobs:
-  ruff:
-    name: Ruff Lint
+  determine-python:
+    name: Determine Python Version
     runs-on: ubuntu-latest
+    outputs:
+      python-version: ${{ steps.get-version.outputs.python }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python (bootstrap)
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Determine python version from pyproject.toml
+        id: get-version
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import tomllib
+          import sys
+          data = tomllib.load(open("pyproject.toml", "rb"))
+          rp = data.get("project", {}).get("requires-python", "")
+          if not rp:
+              version = "3.13"
+          else:
+              m = re.search(r"(\d+\.\d+(?:\.\d+)?)", rp)
+              if m:
+                  version = m.group(1)
+              else:
+                  version = "3.13"
+          parts = version.split(".")
+          version = f"{parts[0]}.{parts[1]}"
+          print(f"python={version}")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f"python={version}\n")
+          PY
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    needs: determine-python
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
-      - name: Install dependencies
+          python-version: ${{ needs.determine-python.outputs.python-version }}
+      - name: Install build tools
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m pip install --upgrade pip build
+      - name: Build sdist and wheel
+        run: |
+          python -m build --sdist --wheel
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  ruff:
+    name: Ruff Lint
+    runs-on: ubuntu-latest
+    needs: determine-python
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ needs.determine-python.outputs.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+      - name: Install ruff
+        run: pip install ruff
       - name: Run ruff
-        run: |
-          python -m ruff check .
+        run: python -m ruff check .
 
   tests:
     name: Run Tests
     runs-on: ubuntu-latest
-    needs: ruff
+    needs:
+      - build
+      - ruff
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
-      - name: Install dependencies
+          python-version: ${{ needs.determine-python.outputs.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Install package and test tools
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m pip install dist/*.whl
+          python -m pip install pytest pytest-mock
       - name: Run pytest
-        run: |
-          python -m pytest tests/ -v
+        run: python -m pytest tests/ -v
 
   coverage:
     name: Coverage (fail if < 80%)
     runs-on: ubuntu-latest
-    needs: tests
+    needs:
+      - build
+      - tests
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
-      - name: Install dependencies
+          python-version: ${{ needs.determine-python.outputs.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Install package and coverage tools
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m pip install dist/*.whl
+          python -m pip install pytest pytest-cov
       - name: Run tests with coverage and enforce threshold
         run: |
           python -m pytest --cov=api_utils --cov=data_utils --cov=main \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run tests with coverage and enforce threshold
         run: |
           python -m pytest --cov=api_utils --cov=data_utils --cov=main \
-            --cov-report=term-missing --cov-fail-under=80 tests/
+            --cov-report=term-missing --cov-report=html --cov-fail-under=80 tests/
       - name: Upload coverage HTML (artifact)
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .coverage
 htmlcov/
 .pytest_cache/
+.vscode/


### PR DESCRIPTION
# Pull Request: Implement GitHub Actions CI Pipeline

## Overview
This pull request introduces a complete continuous integration (CI) workflow using GitHub Actions.  
The pipeline automatically runs linting, tests, and coverage validation on every push and pull request, ensuring consistent code quality throughout the project.

## Changes

### GitHub Actions Workflow
A new CI pipeline (`.github/workflows/ci.yml`) has been added with five structured jobs:

#### **1. Determine Python Version**
- Parses `pyproject.toml` to extract the required Python version from `project.requires-python`.
- Dynamically determines the Python version to use across all jobs.
- Defaults to Python 3.13 if not specified.
- Outputs the version as a workflow variable for reuse by downstream jobs.

#### **2. Build Package**
- Builds the Python package (wheel and sdist) using `python -m build`.
- Uploads the `dist/` artifact for reuse by tests and coverage jobs.
- Avoids rebuilding the package multiple times across jobs.

#### **3. Ruff Lint** (Parallel with Build)
- Installs development dependencies via `pip install -e ".[dev]"`.
- Runs the ruff linter to validate code style and static analysis:

```bash
python -m ruff check .
```

- Runs in parallel with the Build job for faster feedback.

#### **4. Test Execution**
- Runs after both linting and build succeed (fail-fast on lint errors).
- Downloads the pre-built wheel artifact and installs it.
- Executes the full test suite using:

```bash
pytest tests/ -v
```

- Uses the dynamically determined Python version.

#### **5. Coverage Enforcement**
- Executes only when all tests pass.
- Downloads the pre-built wheel artifact and installs it.
- Runs pytest with coverage collection and enforces the minimum threshold:

```
pytest --cov=api_utils --cov=data_utils --cov=main \
       --cov-report=term-missing --cov-fail-under=80 tests/
```

- Enforces a minimum **80%** code coverage; fails the job if coverage is lower.
- Uploads the HTML coverage report (`htmlcov/`) as a pipeline artifact for detailed inspection.

### Dependency Management
- All dependencies are sourced from `pyproject.toml` via `pip install -e ".[dev]"`.
- Single source of truth for dev tools (ruff, pytest, pytest-mock, pytest-cov).
- Easy maintenance: add/remove tools in `pyproject.toml` and CI automatically picks them up.

### Performance Optimizations
- **Parallel execution**: Ruff and Build jobs run simultaneously.
- **Build artifact reuse**: Tests and Coverage jobs download the pre-built wheel instead of rebuilding.
- **Pip caching**: Caches `~/.cache/pip` across jobs to speed up dependency installs.

## Benefits
- **Automated Code Quality**: Ensures linting, testing, and coverage checks run consistently for all PRs.
- **Dynamic Python Version**: Automatically uses the Python version specified in `pyproject.toml`.
- **Efficient CI**: Builds once, reuses artifacts; ruff and build run in parallel.
- **Fail Fast**: Linting errors block tests from running, saving CI time.
- **Immediate Feedback**: Contributors get rapid validation of their changes.
- **Coverage Insights**: Automatically uploads HTML coverage to help identify untested code paths.
- **Prevent Regressions**: Enforces best practices and maintains project health through automation.

## Pipeline Summary

| Job              | Description                                  | Depends On          |
|------------------|----------------------------------------------|---------------------|
| determine-python | Parse pyproject.toml for Python version      | —                   |
| build            | Build wheel and sdist artifacts              | determine-python    |
| ruff             | Run ruff linter                              | determine-python    |
| tests            | Execute pytest test suite                    | build + ruff        |
| coverage         | Enforce ≥80% coverage, upload HTML report    | tests               |

## Trigger Conditions
The CI runs automatically on:

- **Push** events to:  
  - `main`  
  - `feature/*` branches
- **Pull requests** targeting:  
  - `main`

No manual intervention required from contributors.